### PR TITLE
Missing array copy in generated code

### DIFF
--- a/src/compiler/objc_message_field.cc
+++ b/src/compiler/objc_message_field.cc
@@ -377,7 +377,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
       "  return self;\n"
       "}\n"
       "- ($classname$_Builder *)set$capitalized_name$Array:(NSArray *)array {\n"
-      "  result.$list_name$ = [[NSMutableArray alloc]init];\n"
+      "  result.$list_name$ = [[NSMutableArray alloc]initWithArray:array];\n"
       "  return self;\n"
       "}\n"
       "- ($classname$_Builder *)clear$capitalized_name$ {\n"


### PR DESCRIPTION
The compiler plugin did not generate correct code for the setXXXArray method for repeated message fields, probably a copy/paste error. It was correct for the repeated primitive fields.
